### PR TITLE
Link Text formatting

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -15,38 +15,43 @@
         </div>
     </div>
     <div id="content">
-        <p>This is my portfolio.</p>
+        </br>
+        <h1>Welcome!</h1>
         <p>Hello! My name is Leah and I'm excited to be a STEP Intern this summer!</p>
         <br>
 
         <div class = "subParagraphs">
-        	<div class = "subPar" onclick="expand('about')"><h2>About me</h2></div>
-        	<div class = "subPar" onclick="expand('projects')"><h2>Past Projects</h2></div>
-            <div class = "subPar" onclick="expand('facts')"><h2>Fun Facts</h2></div>
-        	<div class = "subPar" onclick="expand('links')"><h2>Links</h2></div>
+        	<div class = "subPar" onclick="expand('about')"><h2 class = "link">About me</h2></div>
+        	<div class = "subPar" onclick="expand('projects')"><h2 class = "link">Past Projects</h2></div>
+            <div class = "subPar" onclick="expand('facts')"><h2 class = "link">Fun Facts</h2></div>
          </div>
         <div id= "about-container"></div>
         </br>
-        <a href= "https://www.linkedin.com/in/leah-attai-203">LinkedIn </a> </br>
-        <a href= "https://github.com/lattai">GitHub </a> </br>
+         </br>
         
-        <div id = "galleryBox">
-        <h2>Gallery</h2>
-        <div id = "gallery">
-            <div id = "gwc" class = "image"> 
-                <a target ="_blank" alt = "Girls Who Code" href = "https://www.google.com/url?sa=i&url=https%3A%2F%2Fmedium.com%2F%40GirlsWhoCode%2Fstay-curious-patience-in-coding-leah-attai-fb20cb3a6219&psig=AOvVaw2Cyv0bVxYUoMYil6qA-mgZ&ust=1590176828049000&source=images&cd=vfe&ved=0CAMQjB1qFwoTCODsjrrcxekCFQAAAAAdAAAAABAR">
-                <img src = "/images/gwc.jpeg" alt = "Girls Who Code"></a>
+        <center> <div id = "galleryBox">
+            <h2>Gallery</h2>
+            <div id = "gallery">
+                <div id = "gwc" class = "image"> 
+                    <a target ="_blank" alt = "Girls Who Code" href = "https://medium.com/@GirlsWhoCode/stay-curious-patience-in-coding-leah-attai-fb20cb3a6219">
+                    <img src = "/images/gwc.jpeg" alt = "Girls Who Code"></a>
+                </div>
+                <div id = "csc" class = "image"> 
+                    <a target ="_blank" alt = "Coding @ Cardinal Shehan" href = "https://www.ctpost.com/local/article/Bringing-girls-up-to-Scratch-13092641.php">
+                    <img src = "/images/csh.jpg" alt = "Coding @ Cardinal Shehan"></a>
+                </div>
+                <div id = "technica" class = "image">
+                    <a target ="_blank" alt = "Technica 2019" href = "https://www.gettysburg.edu/news/stories?id=854d16d8-f587-48a0-b78b-97d718e45a5c&pageTitle=Computer+Science+students+at+Gettysburg+got+it+done%21">
+                    <img src = "/images/technica.jpg" alt = "Technica 2019"></a>
+                </div>
             </div>
-            <div id = "csc" class = "image"> 
-               <a target ="_blank" alt = "Coding @ Cardinal Shehan" href = "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.ctpost.com%2Flocal%2Farticle%2FBringing-girls-up-to-Scratch-13092641.php&psig=AOvVaw2Cyv0bVxYUoMYil6qA-mgZ&ust=1590176828049000&source=images&cd=vfe&ved=0CAMQjB1qFwoTCODsjrrcxekCFQAAAAAdAAAAABAV">
-                <img src = "/images/csh.jpg" alt = "Coding @ Cardinal Shehan"></a>
+        </div> </center>
+        </br>
+        <h1> Where can you find me? </h1>
+            <div id = "links">
+                <a class = "link" href= "https://www.linkedin.com/in/leah-attai-203">LinkedIn</a>
+                <a class = "link" href= "https://github.com/lattai">GitHub</a>
             </div>
-            <div id = "technica" class = "image">
-                <a target ="_blank" alt = "Technica 2019" href ="https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.gettysburg.edu%2Fnews%2Fstories%3Fid%3D854d16d8-f587-48a0-b78b-97d718e45a5c%26pageTitle%3DComputer%2BScience%2Bstudents%2Bat%2BGettysburg%2Bgot%2Bit%2Bdone%2521&psig=AOvVaw2Cyv0bVxYUoMYil6qA-mgZ&ust=1590176828049000&source=images&cd=vfe&ved=0CAMQjB1qFwoTCODsjrrcxekCFQAAAAAdAAAAABAa">
-                <img src = "/images/technica.jpg" alt = "Technica 2019"></a>
-            </div>
-        </div>
-        </div>
     </div>
   </body>
 </html>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -47,5 +47,4 @@ function expand(info){
         	aboutMeContainer.innerText = "LINKS Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.LINKS "
     	}
     }
-    
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -2,9 +2,10 @@
   margin-left: auto;
   margin-right: auto;
   width: 85%;
+  text-align: center;
 }
 body {
-    background-color: rgb(108, 160, 115)
+    background-color: rgb(108, 160, 115);
 }
 
 #heading {
@@ -22,21 +23,29 @@ body {
 #rectangle{
     height: 125px;
     width: 50%;
+    border-radius: 0px 10px 10px 0px;
     background-color: rgb(108, 160, 115);
     opacity: 0.95;
     font-family: 'Permanent Marker';
-    color: white;
+    color: antiquewhite;
+    text-shadow: 1px 2px rgb(230, 87, 0);
     font-size: 30px;
     text-align: center;
     padding: 0px;
-    line-height: 1;
+    line-height: 1.5;
 
 }
-
 h3 {
     font-size: 30px;
     line-height: 0.2;
+    text-shadow: none;
 }
+h1 {
+    font-family: 'Permanent Marker';
+    color: antiquewhite;
+    font-size: 45px;
+}
+
 
 /* Gallery */
 #galleryBox {
@@ -45,12 +54,12 @@ h3 {
     border-radius: 5px;
     font-family: 'Permanent Marker';
     color: rgb(108, 160, 115);
+    text-shadow: 1px 2px rgb(230, 87, 0);
     font-size: 30px;
     text-align: center;
     line-height: 0;
-    width: 90%
+    width: 1000px;
 }
-
 #gallery {
     width: auto;
     display: flex;
@@ -64,9 +73,6 @@ h3 {
    opacity: 0.8; 
 }
 
-
-
-
 /* Subparagraph Flexbox */
 #expand {
   margin-top: 20px;
@@ -75,10 +81,30 @@ h3 {
     display: flex;
     justify-content: space-evenly;
 }
-.subPar:hover {
-    background-color: lightcyan;
+.subpar {
+    border-radius: 10px;
+    padding-left: 10px;
+    padding-right: 10px;
 }
+/* .subPar:hover {
+    background-color: lightcyan;
+} */
 
 #about-container {
     background-color: lightcyan;
+}
+
+/* Social Links */
+#links{
+    display: flex;
+    justify-content: space-evenly;
+}
+.link {
+    font-family: 'Permanent Marker';
+    color: antiquewhite;
+    font-size: 25px;
+    text-decoration: none;
+}
+.link:hover {
+    text-shadow: 1px 2px rgb(230, 87, 0);
 }


### PR DESCRIPTION
The links (Linkedin GitHub) were moved to the bottom of the page as a standalone section. Title and gallery heading have text shadow, and and links have text shadow on Mouse over (See 'Fun Facts' in image).

This is what it looks like now:
![Text Formatting](https://user-images.githubusercontent.com/30049526/83068552-864b9580-a036-11ea-99da-f8c6048f4b32.png)
